### PR TITLE
feat!: commit generated files

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -44,10 +44,7 @@ export class Project extends ProjenProject {
   public readonly lintTask: Task;
 
   constructor(options: ProjectOptions) {
-    super({
-      ...options,
-      commitGenerated: false,
-    });
+    super(options);
 
     this.addGitIgnore("/.turbo");
 


### PR DESCRIPTION
Not committing projen generated files has been proven to cause annoyances, such as having to run `projen` every time a repository receives updates.
